### PR TITLE
Content descriptions initial info

### DIFF
--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/data/AccessibilityCatalogDataSource.kt
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/data/AccessibilityCatalogDataSource.kt
@@ -5,9 +5,11 @@ import com.telefonica.apps.accessibility_catalog.view.models.AccessibilityElemen
 import com.telefonica.apps.accessibility_catalog.view.models.TextLink
 import com.telefonica.apps.accessibility_catalog.view.screens.common.AndroidViewImplementation
 import com.telefonica.apps.accessibility_catalog.view.screens.common.ComposeImplementation
+import com.telefonica.apps.accessibility_catalog.view.screens.implementations.compose.contentdescriptions.ContentDescriptionsCompose
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.compose.headings.Headings
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.compose.toggleables.ToggleablesCompose
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.compose.touchtarget.TouchTarget
+import com.telefonica.apps.accessibility_catalog.view.screens.implementations.views.contentdescriptions.ContentDescriptionsView
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.views.headings.HeadingsView
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.views.toggleables.ToggleablesView
 import com.telefonica.apps.accessibility_catalog.view.screens.implementations.views.touchtarget.TouchTargetView
@@ -134,6 +136,45 @@ class AccessibilityCatalogDataSource @Inject constructor() {
                 ComposeImplementation(
                     composable = { ToggleablesCompose() },
                     documentationUrl = R.string.toggleables_implementation_compose_documentation_url
+                )
+            },
+        ),
+        //endregion
+
+        //region Content Descriptions
+        AccessibilityElement(
+            id = UUID.randomUUID(),
+            nameResId = R.string.content_descriptions_title_section,
+            iconResId = R.drawable.ic_content_description,
+            abstractResId = R.string.content_descriptions_abstract,
+            requirementsResId = listOf(
+                R.string.content_descriptions_requirement_meaningful_descriptions,
+                R.string.content_descriptions_requirement_avoid_redundancy,
+                R.string.content_descriptions_requirement_context_aware,
+                R.string.content_descriptions_requirement_decorative_images,
+            ),
+            relatedLinksResId = listOf(
+                TextLink(
+                    url = R.string.content_descriptions_related_link_1,
+                    nameResId = R.string.related_link_android_documentation,
+                ),
+                TextLink(
+                    url = R.string.content_descriptions_related_link_2,
+                    nameResId = R.string.related_link_magenta,
+                ),
+            ),
+            xmlViewImplementation = {
+                AndroidViewImplementation(
+                    factory = { context ->
+                        ContentDescriptionsView(context = context)
+                    },
+                    documentationUrl = R.string.content_descriptions_implementation_xml_documentation_url
+                )
+            },
+            composeImplementation = {
+                ComposeImplementation(
+                    composable = { ContentDescriptionsCompose() },
+                    documentationUrl = R.string.content_descriptions_implementation_compose_documentation_url
                 )
             },
         ),

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
@@ -1,0 +1,253 @@
+package com.telefonica.apps.accessibility_catalog.view.screens.implementations.compose.contentdescriptions
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.telefonica.apps.accessibility_catalog.R
+
+@Composable
+fun ContentDescriptionsCompose() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp)
+    ) {
+        // 1. Meaningful description (Informative image)
+        Text(
+            text = stringResource(R.string.content_descriptions_informative_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_informative_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Image(
+            painter = painterResource(id = R.drawable.sunnyweather),
+            contentDescription = stringResource(R.string.content_descriptions_implementation_weather_description),
+            modifier = Modifier.size(96.dp)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 2. Actionable icon (Context-aware/action description)
+        Text(
+            text = stringResource(R.string.content_descriptions_actionable_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_actionable_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        IconButton(onClick = { /* Handle delete */ }) {
+            Image(
+                painter = painterResource(id = R.drawable.baseline_close_24),
+                contentDescription = stringResource(R.string.content_descriptions_implementation_delete_button),
+                modifier = Modifier.size(48.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 3. Decorative image (no content description)
+        Text(
+            text = stringResource(R.string.content_descriptions_decorative_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_decorative_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Image(
+            painter = painterResource(id = R.drawable.black_dot),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 4. Complex graphic (context-aware/meaningful description)
+        Text(
+            text = stringResource(R.string.content_descriptions_complex_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_implementation_chart_description),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Image(
+            painter = painterResource(id = R.drawable.sales_per_quarter),
+            contentDescription = stringResource(R.string.content_descriptions_implementation_chart_description),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 5. Redundancy avoidance (bad and good example)
+        Text(
+            text = stringResource(R.string.content_descriptions_redundancy_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_redundancy_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        // Incorrect example
+        Text(
+            text = stringResource(R.string.content_descriptions_incorrect),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            IconButton(onClick = { /* Handle action */ }) {
+                Image(
+                    painter = painterResource(id = R.drawable.baseline_close_24),
+                    contentDescription = stringResource(R.string.content_descriptions_implementation_delete_button),
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+            Text(
+                text = stringResource(R.string.content_descriptions_implementation_delete_button),
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+        Text(
+            text = stringResource(R.string.content_descriptions_redundancy_incorrect_explanation),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(start = 40.dp, bottom = 12.dp)
+        )
+        // Correct example
+        Text(
+            text = stringResource(R.string.content_descriptions_correct),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        val deleteButtonContentDescription = stringResource(R.string.content_descriptions_implementation_delete_button)
+        Row(
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            modifier = Modifier
+                .clickable { /* Handle action */ }
+                .semantics {
+                    contentDescription = deleteButtonContentDescription
+                }
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.baseline_close_24),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clearAndSetSemantics {}
+            )
+            Text(
+                text = stringResource(R.string.content_descriptions_implementation_delete_button),
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .clearAndSetSemantics {}
+            )
+        }
+        Text(
+            text = stringResource(R.string.content_descriptions_redundancy_correct_explanation),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(start = 40.dp, bottom = 24.dp)
+        )
+
+        // 6. Context-aware (status indicator)
+        Text(
+            text = stringResource(R.string.content_descriptions_contextual_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_contextual_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Row {
+            Image(
+                painter = painterResource(id = R.drawable.black_dot),
+                contentDescription = stringResource(R.string.content_descriptions_status_online),
+                modifier = Modifier.size(16.dp)
+            )
+            Text(
+                text = stringResource(R.string.content_descriptions_status_online_label),
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 7. Phone Number Accessibility
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_explanation),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        // Incorrect example
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_incorrect_label),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_raw),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_incorrect_explanation),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        // Correct example
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_correct_label),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+        )
+        val spacedPhoneNumber = stringResource(R.string.content_descriptions_phone_number_spaced)
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_raw),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.semantics {
+                contentDescription = spacedPhoneNumber
+            }
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_phone_number_correct_explanation),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -24,230 +25,263 @@ fun ContentDescriptionsCompose() {
             .fillMaxWidth()
             .padding(24.dp)
     ) {
-        // 1. Meaningful description (Informative image)
-        Text(
-            text = stringResource(R.string.content_descriptions_informative_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_informative_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Image(
-            painter = painterResource(id = R.drawable.sunnyweather),
-            contentDescription = stringResource(R.string.content_descriptions_implementation_weather_description),
-            modifier = Modifier.size(96.dp)
-        )
-        Spacer(modifier = Modifier.height(24.dp))
+        Example1MeaningfulDescription()
 
-        // 2. Actionable icon (Context-aware/action description)
-        Text(
-            text = stringResource(R.string.content_descriptions_actionable_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
+        Example2ActionableIcon()
+
+        Example3DecorativeImage()
+
+        Example4ComplexGraphic()
+
+        Example5RedundancyAvoidance()
+
+        Example6ContextualDescriptions()
+
+        Example7PhoneNumberAccessibility()
+    }
+}
+
+@Composable
+private fun Example1MeaningfulDescription() {
+    Text(
+        text = stringResource(R.string.content_descriptions_informative_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_informative_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Image(
+        painter = painterResource(id = R.drawable.sunnyweather),
+        contentDescription = stringResource(R.string.content_descriptions_implementation_weather_description),
+        modifier = Modifier.size(96.dp)
+    )
+    Spacer(modifier = Modifier.height(24.dp))
+}
+
+@Composable
+private fun Example2ActionableIcon() {
+    Text(
+        text = stringResource(R.string.content_descriptions_actionable_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_actionable_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    IconButton(onClick = { /* Handle delete */ }) {
+        Image(
+            painter = painterResource(id = R.drawable.baseline_close_24),
+            contentDescription = stringResource(R.string.content_descriptions_implementation_delete_button),
+            modifier = Modifier.size(48.dp)
         )
-        Text(
-            text = stringResource(R.string.content_descriptions_actionable_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        IconButton(onClick = { /* Handle delete */ }) {
+    }
+    Spacer(modifier = Modifier.height(24.dp))
+}
+
+@Composable
+private fun Example3DecorativeImage() {
+    Text(
+        text = stringResource(R.string.content_descriptions_decorative_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_decorative_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Image(
+        painter = painterResource(id = R.drawable.black_dot),
+        contentDescription = null,
+        modifier = Modifier.size(24.dp)
+    )
+    Spacer(modifier = Modifier.height(24.dp))
+}
+
+@Composable
+private fun Example4ComplexGraphic() {
+    Text(
+        text = stringResource(R.string.content_descriptions_complex_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_implementation_chart_description),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Image(
+        painter = painterResource(id = R.drawable.sales_per_quarter),
+        contentDescription = stringResource(R.string.content_descriptions_implementation_chart_description),
+        modifier = Modifier.fillMaxWidth()
+    )
+    Spacer(modifier = Modifier.height(24.dp))
+}
+
+@Composable
+private fun Example5RedundancyAvoidance() {
+    Text(
+        text = stringResource(R.string.content_descriptions_redundancy_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_redundancy_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    // region Incorrect example
+    Text(
+        text = stringResource(R.string.content_descriptions_incorrect),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 4.dp)
+    )
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = { /* Handle action */ }) {
             Image(
                 painter = painterResource(id = R.drawable.baseline_close_24),
                 contentDescription = stringResource(R.string.content_descriptions_implementation_delete_button),
-                modifier = Modifier.size(48.dp)
-            )
-        }
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // 3. Decorative image (no content description)
-        Text(
-            text = stringResource(R.string.content_descriptions_decorative_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_decorative_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Image(
-            painter = painterResource(id = R.drawable.black_dot),
-            contentDescription = null,
-            modifier = Modifier.size(24.dp)
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // 4. Complex graphic (context-aware/meaningful description)
-        Text(
-            text = stringResource(R.string.content_descriptions_complex_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_implementation_chart_description),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Image(
-            painter = painterResource(id = R.drawable.sales_per_quarter),
-            contentDescription = stringResource(R.string.content_descriptions_implementation_chart_description),
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // 5. Redundancy avoidance (bad and good example)
-        Text(
-            text = stringResource(R.string.content_descriptions_redundancy_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_redundancy_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        // Incorrect example
-        Text(
-            text = stringResource(R.string.content_descriptions_incorrect),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
-        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-            IconButton(onClick = { /* Handle action */ }) {
-                Image(
-                    painter = painterResource(id = R.drawable.baseline_close_24),
-                    contentDescription = stringResource(R.string.content_descriptions_implementation_delete_button),
-                    modifier = Modifier.size(32.dp)
-                )
-            }
-            Text(
-                text = stringResource(R.string.content_descriptions_implementation_delete_button),
-                modifier = Modifier.padding(start = 8.dp)
+                modifier = Modifier.size(32.dp)
             )
         }
         Text(
-            text = stringResource(R.string.content_descriptions_redundancy_incorrect_explanation),
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(start = 40.dp, bottom = 12.dp)
-        )
-        // Correct example
-        Text(
-            text = stringResource(R.string.content_descriptions_correct),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
-        val deleteButtonContentDescription = stringResource(R.string.content_descriptions_implementation_delete_button)
-        Row(
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-            modifier = Modifier
-                .clickable { /* Handle action */ }
-                .semantics {
-                    contentDescription = deleteButtonContentDescription
-                }
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.baseline_close_24),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(32.dp)
-                    .clearAndSetSemantics {}
-            )
-            Text(
-                text = stringResource(R.string.content_descriptions_implementation_delete_button),
-                modifier = Modifier
-                    .padding(start = 8.dp)
-                    .clearAndSetSemantics {}
-            )
-        }
-        Text(
-            text = stringResource(R.string.content_descriptions_redundancy_correct_explanation),
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(start = 40.dp, bottom = 24.dp)
-        )
-
-        // 6. Context-aware (status indicator)
-        Text(
-            text = stringResource(R.string.content_descriptions_contextual_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_contextual_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Row {
-            Image(
-                painter = painterResource(id = R.drawable.black_dot),
-                contentDescription = stringResource(R.string.content_descriptions_status_online),
-                modifier = Modifier.size(16.dp)
-            )
-            Text(
-                text = stringResource(R.string.content_descriptions_status_online_label),
-                modifier = Modifier.padding(start = 8.dp)
-            )
-        }
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // 7. Phone Number Accessibility
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_explanation),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        // Incorrect example
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_incorrect_label),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_raw),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_incorrect_explanation),
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        // Correct example
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_correct_label),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
-        )
-        val spacedPhoneNumber = stringResource(R.string.content_descriptions_phone_number_spaced)
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_raw),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.semantics {
-                contentDescription = spacedPhoneNumber
-            }
-        )
-        Text(
-            text = stringResource(R.string.content_descriptions_phone_number_correct_explanation),
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(bottom = 8.dp)
+            text = stringResource(R.string.content_descriptions_implementation_delete_button),
+            modifier = Modifier.padding(start = 8.dp)
         )
     }
+    Text(
+        text = stringResource(R.string.content_descriptions_redundancy_incorrect_explanation),
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(start = 40.dp, bottom = 12.dp)
+    )
+    // endregion
+    // region Correct example
+    Text(
+        text = stringResource(R.string.content_descriptions_correct),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 4.dp)
+    )
+    val deleteButtonContentDescription =
+        stringResource(R.string.content_descriptions_implementation_delete_button)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .clickable { /* Handle action */ }
+            .semantics {
+                contentDescription = deleteButtonContentDescription
+            }
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.baseline_close_24),
+            contentDescription = null,
+            modifier = Modifier
+                .size(32.dp)
+                .clearAndSetSemantics {}
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_implementation_delete_button),
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .clearAndSetSemantics {}
+        )
+    }
+    Text(
+        text = stringResource(R.string.content_descriptions_redundancy_correct_explanation),
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(start = 40.dp, bottom = 24.dp)
+    )
+    // endregion
+}
+
+@Composable
+private fun Example6ContextualDescriptions() {
+    Text(
+        text = stringResource(R.string.content_descriptions_contextual_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_contextual_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    Row {
+        Image(
+            painter = painterResource(id = R.drawable.black_dot),
+            contentDescription = stringResource(R.string.content_descriptions_status_online),
+            modifier = Modifier.size(16.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_descriptions_status_online_label),
+            modifier = Modifier.padding(start = 8.dp)
+        )
+    }
+    Spacer(modifier = Modifier.height(24.dp))
+}
+
+@Composable
+private fun Example7PhoneNumberAccessibility() {
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_title),
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_explanation),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    // region Incorrect example
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_incorrect_label),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_raw),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_incorrect_explanation),
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    // endregion
+    // region Correct example
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_correct_label),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+    )
+    val spacedPhoneNumber = stringResource(R.string.content_descriptions_phone_number_spaced)
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_raw),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.semantics {
+            contentDescription = spacedPhoneNumber
+        }
+    )
+    Text(
+        text = stringResource(R.string.content_descriptions_phone_number_correct_explanation),
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+    // endregion
 }

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/ContentDescriptions.kt
@@ -2,7 +2,13 @@ package com.telefonica.apps.accessibility_catalog.view.screens.implementations.c
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/README.md
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions/README.md
@@ -1,0 +1,20 @@
+# Compose Implementation for Content Descriptions
+
+This section demonstrates how to implement accessible content descriptions using Jetpack Compose. The examples focus on:
+
+- Meaningful descriptions
+- Avoiding redundancy
+- Context-aware descriptions
+- Handling decorative images
+
+## Example
+```kotlin
+Image(
+    painter = painterResource(id = R.drawable.example_image),
+    contentDescription = stringResource(R.string.meaningful_description)
+)
+```
+
+>[!TIP]
+>Always provide meaningful and context-aware content descriptions for interactive elements. Avoid redundant descriptions and use `contentDescription = null` for decorative images so they are ignored by screen readers.
+

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/contentdescriptions/ContentDescriptionsView.kt
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/contentdescriptions/ContentDescriptionsView.kt
@@ -1,0 +1,19 @@
+package com.telefonica.apps.accessibility_catalog.view.screens.implementations.views.contentdescriptions
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import com.telefonica.apps.accessibility_catalog.R
+
+class ContentDescriptionsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    init {
+        orientation = VERTICAL
+        LayoutInflater.from(context).inflate(R.layout.content_descriptions, this, true)
+    }
+}

--- a/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/contentdescriptions/README.md
+++ b/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/contentdescriptions/README.md
@@ -1,0 +1,18 @@
+# XML View Implementation for Content Descriptions
+
+This section demonstrates how to implement accessible content descriptions in classic Android Views. The examples focus on:
+
+- Meaningful descriptions
+- Avoiding redundancy
+- Context-aware descriptions
+- Handling decorative images
+
+## Example
+```kotlin
+val imageView = findViewById<ImageView>(R.id.example_image)
+imageView.contentDescription = getString(R.string.meaningful_description)
+```
+
+>[!TIP]
+>Always provide meaningful and context-aware content descriptions for interactive elements. Avoid redundant descriptions and mark decorative images with `null` contentDescription to prevent them from being announced by screen readers.
+

--- a/app/src/main/res/drawable/ic_content_description.xml
+++ b/app/src/main/res/drawable/ic_content_description.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>
+

--- a/app/src/main/res/drawable/sales_per_quarter.xml
+++ b/app/src/main/res/drawable/sales_per_quarter.xml
@@ -1,0 +1,256 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="1183.25dp"
+    android:height="850.83dp"
+    android:viewportWidth="975.33"
+    android:viewportHeight="936.18">
+  <path
+      android:pathData="m215.44,1057.33 l7.46,7.46 7.46,-7.46 69.59,0 0,-42.29 -155.18,0 0.43,41.87 70.23,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="234.13"
+          android:startY="1062.2"
+          android:endX="234.13"
+          android:endY="1028.38"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m730.38,1057.33 l7.46,7.46 7.46,-7.46 150.84,0 0,-42.29 -319.79,0 0.43,41.87 153.59,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="144.6"
+          android:startY="1062.14"
+          android:endX="144.6"
+          android:endY="1028.32"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m427.65,1057.25 l11.32,7.43 11.32,-7.43 105.57,0 0,-42.07 -235.42,0 0.65,41.66 106.55,0.41 0,0z"
+      android:strokeWidth="1.35180533"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="456.01"
+          android:startY="1062.09"
+          android:endX="456.01"
+          android:endY="1028.44"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m81.1,1057.33 l7.46,7.46 7.46,-7.46 28.38,0 0,-42.29 -72.64,0 0.43,41.87 28.9,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="-379.98"
+          android:startY="1062.14"
+          android:endX="-379.98"
+          android:endY="1028.32"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m-79.24,883.28 l7.46,7.46 7.46,-7.46 69.59,0 0,-42.29 -155.18,0 0.43,41.87 70.23,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="-60.55"
+          android:startY="888.14"
+          android:endX="-60.55"
+          android:endY="854.32"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m-147.59,827.16c-1.52,0 -2.75,1.04 -2.75,2.34l0,0.23 0,0.09 0,10.71 73.55,0 0,-10.71 0.03,0 0,-0.32c0,-1.29 -1.23,-2.34 -2.75,-2.34l-68.08,0 0,-0z"
+      android:fillColor="#4cafd9"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m-65.17,785.12c-1.52,0 -2.75,1.22 -2.75,2.74l0,0.24 0,0.14 0,52.29 73.58,0 0,-52.29 0,-0.14 0,-0.24c0,-1.52 -1.23,-2.74 -2.75,-2.74l-68.08,0 0,0z"
+      android:fillColor="#4cafd9"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m181.28,883.28 l7.46,7.46 7.46,-7.46 150.84,0 0,-42.29 -319.79,0 0.43,41.87 153.59,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="-61.35"
+          android:startY="888.14"
+          android:endX="-61.35"
+          android:endY="854.32"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m29.47,725.9c-1.52,0 -2.75,1.26 -2.75,2.81l0,0.28 0,0.11 0,111.42 73.58,0 0,-111.42 0,-0.11 0,-0.28c0,-1.56 -1.23,-2.81 -2.75,-2.81l-68.08,0z"
+      android:fillColor="#4cafd9"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m112.11,756.2c-1.52,0 -2.75,1.24 -2.75,2.79l0,0.38 0.03,0 0,81.15 73.55,0 0,-81.15 0,-0.1 0,-0.28c0,-1.54 -1.23,-2.79 -2.75,-2.79l-68.08,0 0,0z"
+      android:fillColor="#4cafd9"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m194.57,805.02c-1.52,0 -2.75,1.18 -2.75,2.65l0,0.27 0,0.1 0,32.48 73.58,0 0,-32.48 0,-0.1 0,-0.27c0,-1.47 -1.23,-2.65 -2.75,-2.65l-68.08,0z"
+      android:fillColor="#4cafd9"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m276.69,499.37c-1.52,0 -2.75,1.28 -2.75,2.87l0,0.29 0,0.11 0,337.89 73.58,0 0,-337.89 0,-0.11 0,-0.29c0,-1.59 -1.23,-2.87 -2.75,-2.87l-68.08,0 0,0z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m535.82,582.65c-1.52,0 -2.75,1.33 -2.75,2.97l0,0.41 0,1.78 0,252.7 73.58,0 0,-252.7 0,-1.78 0,-0.41c0,-1.65 -1.23,-2.97 -2.75,-2.97l-68.08,0 0,0z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m523.09,883.34 l7.46,7.46 7.46,-7.46 150.84,0 0,-42.29 -319.79,0 0.43,41.87 153.59,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="-62.7"
+          android:startY="888.14"
+          android:endX="-62.7"
+          android:endY="854.32"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m371.22,624.49c-1.52,0 -2.75,1.27 -2.75,2.85l0,0.29 0,0.11 0,212.79 73.58,0 0,-212.79 0,-0.11 0,-0.29c0,-1.58 -1.23,-2.85 -2.75,-2.85l-68.08,0z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m453.75,652.72c-1.52,0 -2.75,1.27 -2.75,2.84l0,0.25 0,0.14 0,184.57 73.58,0 0,-184.57 0,-0.14 0,-0.25c0,-1.58 -1.23,-2.84 -2.75,-2.84l-68.08,0 0,0z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m618.27,475.75c-1.52,0 -2.75,1.88 -2.75,4.21l0,0.58 0,2.52 0,357.46 73.58,0 0,-357.46 0,-2.52 0,-0.58c0,-2.33 -1.23,-4.21 -2.75,-4.21l-68.08,0 0,0z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m615.52,840.52 l73.58,0 0,-357.46 0,-2.52 0,-0.58c0,-2.33 -1.23,-4.21 -2.75,-4.21z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m864.86,883.85 l7.46,7.46 7.46,-7.46 150.84,0 0,-42.29 -319.79,0 0.43,41.87 153.59,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="279.07"
+          android:startY="888.66"
+          android:endX="279.07"
+          android:endY="854.84"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m960.19,142.87c-1.52,0 -2.75,1.93 -2.75,4.32l0,0.38 0,0.22 0,693.24 73.58,0 0,-693.24 0,-0.22 0,-0.38c0,-2.39 -1.23,-4.32 -2.75,-4.32l-68.08,0 0,0z"
+      android:fillColor="#c748f1"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m957.43,841.01 l73.58,0 0,-693.24 0,-0.22 0,-0.38c0,-2.39 -1.23,-4.32 -2.75,-4.32z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m713.03,408.41c-1.52,0 -2.75,1.08 -2.75,2.41l0,0.24 0,0.09 0,429.86 73.55,0 0,-429.86 0.03,0 0,-0.33c0,-1.34 -1.23,-2.41 -2.75,-2.41l-68.08,0 0,-0 -0,0z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m710.28,841.01 l73.55,0 0,-429.86 0.03,0 0,-0.33c0,-1.34 -1.23,-2.41 -2.75,-2.41z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m795.42,407.67c-1.52,0 -2.75,1.2 -2.75,2.68l0,0.23 0,0.13 0,430.3 73.58,0 0,-430.3 0,-0.13 0,-0.23c0,-1.49 -1.23,-2.68 -2.75,-2.68l-68.08,0 0,0z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m792.66,841.01 l73.58,0 0,-430.3 0,-0.13 0,-0.23c0,-1.49 -1.23,-2.68 -2.75,-2.68z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m877.8,425.96c-1.52,0 -2.75,1.15 -2.75,2.57l0,0.23 0,0.13 0,412.89 73.58,0 0,-412.89 0,-0.13 0,-0.23c0,-1.43 -1.23,-2.57 -2.75,-2.57l-68.08,0 0,0z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m875.05,841.78 l73.58,0 0,-412.89 0,-0.13 0,-0.23c0,-1.43 -1.23,-2.57 -2.75,-2.57z"
+      android:fillColor="#69c675"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m1054.88,36.91c-1.52,0 -2.75,1.93 -2.75,4.32l0,0.38 0,0.22 0,799.2 73.58,0 0,-799.2 0,-0.22 0,-0.38c0,-2.39 -1.23,-4.32 -2.75,-4.32z"
+      android:fillColor="#c748f1"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m1052.12,841.01 l73.58,0 0,-799.2 0,-0.22 0,-0.38c0,-2.39 -1.23,-4.32 -2.75,-4.32z"
+      android:fillColor="#e89445"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="m1081.93,883.85 l7.46,7.46 7.46,-7.46 28.38,0 0,-42.29 -72.64,0 0.43,41.87 28.9,0.41 0,0z"
+      android:strokeWidth="1.10031366"
+      android:strokeColor="#b7aaaa">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="620.84"
+          android:startY="888.66"
+          android:endX="620.84"
+          android:endY="854.84"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFE8E8E6"/>
+        <item android:offset="1" android:color="#00FFFFFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/app/src/main/res/drawable/sunnyweather.xml
+++ b/app/src/main/res/drawable/sunnyweather.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="439dp" android:viewportHeight="855" android:viewportWidth="583.74" android:width="299.72147dp">
+      
+    <path android:fillColor="#fcee21" android:pathData="M278.28,81.76 L320.99,37a16,16 0,0 1,27.09 7.26L362.7,104.38a16,16 0,0 0,20 11.56L382.7,471.48A16,16 0,0 0,362.7 483L348.08,543.2a16,16 0,0 1,-27.09 7.26l-42.71,-44.8a16,16 0,0 0,-23.13 0l-42.71,44.8a16,16 0,0 1,-27.1 -7.26L170.75,483a16,16 0,0 0,-20 -11.56l-59.39,17.44a16,16 0,0 1,-19.83 -19.83l17.44,-59.39a16,16 0,0 0,-11.56 -20l-60.16,-14.59A16,16 0,0 1,9.96 348l44.8,-42.71a16,16 0,0 0,0 -23.13l-44.8,-42.72a16,16 0,0 1,7.26 -27.09l60.16,-14.59a16,16 0,0 0,11.56 -20L71.5,118.33a16,16 0,0 1,19.83 -19.83L150.7,115.94a16,16 0,0 0,20 -11.56l14.59,-60.16a16,16 0,0 1,27.1 -7.26l42.71,44.8A16,16 0,0 0,278.28 81.76Z" android:strokeColor="#fbb03b" android:strokeWidth="10"/>
+      
+    <path android:fillColor="#fbb03b" android:pathData="M414.62,294c0,130.38 -48.15,174.92 -144.76,174.92a174.93,174.93 0,0 1,0 -349.85C366.47,119.06 414.62,165.76 414.62,294Z"/>
+      
+    <path android:fillColor="#fff" android:pathData="M396.7,847a178.58,178.58 0,0 1,-179 -177.55c-0.67,-85.37 59.43,-159.73 142.91,-176.81l6.4,-1.31L367.01,484.8c0,-0.66 -0.22,-329.59 -0.29,-449.32a27.47,27.47 0,1 1,54.93 0l-0.56,455 6.63,1.16A179.06,179.06 0,0 1,575.7 668C575.7,766.7 495.45,847 396.7,847Z"/>
+      
+    <path android:fillColor="#FF000000" android:pathData="M394.23,16A19.46,19.46 0,0 1,413.7 35.49l-0.55,448.29 0,13.46 13.27,2.32A171,171 0,0 1,396.7 839h0a171,171 0,0 1,-34.48 -338.53l12.8,-2.61L375.02,484.8c0,-0.55 -0.14,-219.5 -0.24,-364.39l0,-84.94A19.44,19.44 0,0 1,394.23 16m0,-16a35.45,35.45 0,0 0,-35.46 35.48c0.07,111.68 0.29,448.65 0.29,449.32A187,187 0,0 0,396.7 855c103.28,0 187,-83.72 187,-187A187,187 0,0 0,429.15 483.8L429.7,35.51A35.47,35.47 0,0 0,394.23 0Z"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.19,451L551.7,451" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.19,385.28L490.7,385.28" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.7,319.84L552.21,319.84" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.7,254.12L491.21,254.12" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.7,188.84L552.21,188.84" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#fff" android:pathData="M429.7,123.12L491.21,123.12" android:strokeColor="#000" android:strokeLineCap="round" android:strokeWidth="16"/>
+      
+    <path android:fillColor="#ff0000" android:pathData="M396.7,665m-161,0a161,161 0,1 1,322 0a161,161 0,1 1,-322 0"/>
+      
+    <path android:fillColor="#00000000" android:pathData="M394.7,522L394.7,123" android:strokeColor="#ff0000" android:strokeWidth="26"/>
+    
+</vector>

--- a/app/src/main/res/layout/content_descriptions.xml
+++ b/app/src/main/res/layout/content_descriptions.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/padding_large">
+
+    <!-- 1. Meaningful description (Informative image) -->
+    <TextView
+        android:id="@+id/informative_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_informative_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/informative_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_informative_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <ImageView
+        android:id="@+id/informative_image"
+        android:layout_width="@dimen/image_size_large"
+        android:layout_height="@dimen/image_size_large"
+        android:src="@drawable/sunnyweather"
+        android:contentDescription="@string/content_descriptions_implementation_weather_description"
+        android:layout_marginBottom="@dimen/margin_large" />
+
+    <!-- 2. Actionable icon (Context-aware/action description) -->
+    <TextView
+        android:id="@+id/actionable_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_actionable_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/actionable_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_actionable_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <ImageView
+        android:id="@+id/actionable_icon"
+        android:layout_width="@dimen/touch_target_min_size"
+        android:layout_height="@dimen/touch_target_min_size"
+        android:src="@drawable/baseline_close_24"
+        android:contentDescription="@string/content_descriptions_implementation_delete_button"
+        android:background="@android:drawable/btn_default"
+        android:focusable="true"
+        android:clickable="true"
+        android:layout_marginBottom="@dimen/margin_large" />
+
+    <!-- 3. Decorative image (no content description) -->
+    <TextView
+        android:id="@+id/decorative_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_decorative_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/decorative_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_decorative_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <ImageView
+        android:id="@+id/decorative_image"
+        android:layout_width="@dimen/image_size_small"
+        android:layout_height="@dimen/image_size_small"
+        android:src="@drawable/black_dot"
+        android:contentDescription="@null"
+        android:layout_marginBottom="@dimen/margin_large" />
+
+    <!-- 4. Complex graphic (context-aware/meaningful description) -->
+    <TextView
+        android:id="@+id/complex_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_complex_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/complex_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_implementation_chart_description"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <ImageView
+        android:id="@+id/complex_image"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:src="@drawable/sales_per_quarter"
+        android:scaleType="fitXY"
+        android:contentDescription="@string/content_descriptions_implementation_chart_description"
+        android:layout_marginBottom="@dimen/margin_large" />
+
+    <!-- 5. Redundancy avoidance (bad and good example) -->
+    <TextView
+        android:id="@+id/redundancy_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_redundancy_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/redundancy_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_redundancy_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <!-- Incorrect example -->
+    <TextView
+        android:id="@+id/redundancy_incorrect_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_incorrect"
+        android:textAppearance="@android:style/TextAppearance.Material.Small" />
+    <LinearLayout
+        android:id="@+id/redundancy_incorrect_row"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <ImageView
+            android:id="@+id/redundancy_incorrect_x"
+            android:layout_width="@dimen/touch_target_min_size"
+            android:layout_height="@dimen/touch_target_min_size"
+            android:src="@drawable/baseline_close_24"
+            android:contentDescription="@string/content_descriptions_implementation_delete_button" />
+        <TextView
+            android:id="@+id/redundancy_incorrect_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content_descriptions_implementation_delete_button"
+            android:contentDescription="@string/content_descriptions_implementation_delete_button"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    </LinearLayout>
+    <TextView
+        android:id="@+id/redundancy_incorrect_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_redundancy_incorrect_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Small" />
+    <!-- Correct example -->
+    <TextView
+        android:id="@+id/redundancy_correct_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_correct"
+        android:textAppearance="@android:style/TextAppearance.Material.Small" />
+    <LinearLayout
+        android:id="@+id/redundancy_correct_row"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:focusable="true"
+        android:clickable="true"
+        android:importantForAccessibility="yes"
+        android:contentDescription="@string/content_descriptions_implementation_delete_button"
+        android:gravity="center_vertical">
+        <ImageView
+            android:id="@+id/redundancy_correct_x"
+            android:layout_width="@dimen/touch_target_min_size"
+            android:layout_height="@dimen/touch_target_min_size"
+            android:src="@drawable/baseline_close_24"
+            android:contentDescription="@null" />
+        <TextView
+            android:id="@+id/redundancy_correct_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content_descriptions_implementation_delete_button"
+            android:contentDescription="@null"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    </LinearLayout>
+    <TextView
+        android:id="@+id/redundancy_correct_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_redundancy_correct_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Small" />
+
+    <!-- 6. Context-aware (status indicator) -->
+    <TextView
+        android:id="@+id/contextual_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_contextual_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline" />
+    <TextView
+        android:id="@+id/contextual_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_contextual_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <LinearLayout
+        android:id="@+id/contextual_row"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <ImageView
+            android:id="@+id/contextual_dot"
+            android:layout_width="@dimen/image_size_small"
+            android:layout_height="@dimen/image_size_small"
+            android:src="@drawable/black_dot"
+            android:contentDescription="@string/content_descriptions_status_online" />
+        <TextView
+            android:id="@+id/contextual_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content_descriptions_status_online_label"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    </LinearLayout>
+
+    <!-- 7. Phone Number Accessibility -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline"
+        android:layout_marginTop="24dp" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1"
+        android:layout_marginBottom="8dp" />
+    <!-- Incorrect example -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_incorrect_label"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:layout_marginTop="8dp" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_raw"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_incorrect_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:layout_marginBottom="8dp" />
+    <!-- Correct example -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_correct_label"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:layout_marginTop="8dp" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_raw"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1"
+        android:contentDescription="@string/content_descriptions_phone_number_spaced" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/content_descriptions_phone_number_correct_explanation"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:layout_marginBottom="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -74,4 +74,55 @@
     <string name="accessibility_checkbox_turn_on_action">turn on</string>
     <string name="accessibility_checkbox_turn_off_action">turn off</string>
 
+    <!-- Content Descriptions -->
+    <string name="content_descriptions_title_section">Content Descriptions</string>
+    <string name="content_descriptions_abstract">Content descriptions provide alternative textual information for visual elements such as images, icons, and other graphic components.
+
+        These descriptions are essential for users who rely on assistive technologies like TalkBack, as they help convey the purpose and content of non-textual elements.
+
+        A good content description should be clear, concise, and contextually relevant.</string>
+    <string name="content_descriptions_requirement_meaningful_descriptions">Provide meaningful descriptions that explain the purpose of the element.</string>
+    <string name="content_descriptions_requirement_avoid_redundancy">Avoid redundancy with text already visible on the screen.</string>
+    <string name="content_descriptions_requirement_context_aware">Adapt descriptions to the context and current state of the element.</string>
+    <string name="content_descriptions_requirement_decorative_images">Omit descriptions for purely decorative images.</string>
+    <string name="content_descriptions_implementation_informative_image">Informative image</string>
+    <string name="content_descriptions_implementation_actionable_icon">Actionable icon</string>
+    <string name="content_descriptions_implementation_decorative_image">Decorative image</string>
+    <string name="content_descriptions_implementation_complex_graphic">Complex graphic</string>
+    <string name="content_descriptions_implementation_weather_description">Sunny weather with a temperature of 30 degrees</string>
+    <string name="content_descriptions_implementation_profile_description">User profile photo</string>
+    <string name="content_descriptions_implementation_chart_description">Bar chart showing sales per quarter</string>
+    <string name="content_descriptions_implementation_delete_button">Delete item</string>
+    <string name="content_descriptions_implementation_share_button">Share content</string>
+    <string name="content_descriptions_informative_title">Informative Images</string>
+    <string name="content_descriptions_actionable_title">Actionable Icons</string>
+    <string name="content_descriptions_decorative_title">Decorative Elements</string>
+    <string name="content_descriptions_complex_title">Complex Graphics</string>
+    <string name="content_descriptions_contextual_title">Contextual Descriptions</string>
+    <string name="content_descriptions_interactive_title">Interactive Components</string>
+    <string name="content_descriptions_profile_picture">Profile picture of Maria Gonzalez</string>
+    <string name="content_descriptions_close_dialog">Close dialog</string>
+    <string name="content_descriptions_add_to_favorites">Add to favorites</string>
+    <string name="content_descriptions_rating_4_out_of_5">Rating: 4 out of 5 stars</string>
+    <string name="content_descriptions_status_online">Status: Online</string>
+    <string name="content_descriptions_article_card">Article: Article title. Preview text. Tap to read more.</string>
+    <string name="content_descriptions_informative_explanation">Example of an informative image with a meaningful description for assistive technology users.</string>
+    <string name="content_descriptions_actionable_explanation">Example of an actionable icon with a description indicating the action it performs.</string>
+    <string name="content_descriptions_decorative_explanation">Example of a decorative image without a description, as it does not provide relevant information.</string>
+    <string name="content_descriptions_redundancy_title">Avoid Redundancy</string>
+    <string name="content_descriptions_redundancy_explanation">Do not repeat information already visible on screen in the content description.</string>
+    <string name="content_descriptions_redundancy_incorrect_explanation">The screen reader will announce twice: \'Delete item\'. This is redundant and may confuse the user.</string>
+    <string name="content_descriptions_redundancy_correct_explanation">The screen reader will announce only once: \'Delete item\'. This is clear and not redundant.</string>
+    <string name="content_descriptions_contextual_explanation">Adapt the description to the current state or context of the element for greater clarity.</string>
+    <string name="content_descriptions_status_online_label">Online</string>
+    <string name="content_descriptions_incorrect">Incorrect</string>
+    <string name="content_descriptions_correct">Correct</string>
+    <string name="content_descriptions_phone_number_title">Phone Number Accessibility</string>
+    <string name="content_descriptions_phone_number_explanation">Screen readers may read phone numbers as a long number, which can be confusing. Using a content description with spaces between digits ensures it is read digit by digit.</string>
+    <string name="content_descriptions_phone_number_incorrect_label">Incorrect</string>
+    <string name="content_descriptions_phone_number_correct_label">Correct</string>
+    <string name="content_descriptions_phone_number_incorrect_explanation">The screen reader will read the number as a long number.</string>
+    <string name="content_descriptions_phone_number_correct_explanation">The screen reader will read the number digit by digit.</string>
+    <string name="content_descriptions_phone_number_raw">656787434</string>
+    <string name="content_descriptions_phone_number_spaced">6 5 6 7 8 7 4 3 4</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,9 @@
+<resources>
+    <dimen name="padding_large">24dp</dimen>
+    <dimen name="image_size_medium">64dp</dimen>
+    <dimen name="margin_large">16dp</dimen>
+    <dimen name="touch_target_min_size">48dp</dimen>
+    <dimen name="image_size_small">24dp</dimen>
+    <dimen name="image_size_large">96dp</dimen>
+</resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,4 +78,57 @@
     <string name="accessibility_checkbox_turn_on_action">activar</string>
     <string name="accessibility_checkbox_turn_off_action">desactivar</string>
 
+    <!-- Content Descriptions -->
+    <string name="content_descriptions_title_section">Descripciones de contenido</string>
+    <string name="content_descriptions_abstract">Las descripciones de contenido proporcionan información textual alternativa para elementos visuales como imágenes, iconos y otros componentes gráficos.
+
+        Esas descripciones son fundamentales para usuarios que utilizan tecnologías de asistencia como TalkBack, ya que permiten comprender el propósito y contenido de elementos no textuales.
+
+        Una buena descripción de contenido debe ser clara, concisa y contextualmente relevante.</string>
+    <string name="content_descriptions_requirement_meaningful_descriptions">Proporciona descripciones significativas que expliquen el propósito del elemento.</string>
+    <string name="content_descriptions_requirement_avoid_redundancy">Evita redundancia con el texto ya visible en pantalla.</string>
+    <string name="content_descriptions_requirement_context_aware">Adapta las descripciones al contexto y estado actual del elemento.</string>
+    <string name="content_descriptions_requirement_decorative_images">Omite descripciones para imágenes puramente decorativas.</string>
+    <string name="content_descriptions_implementation_informative_image">Imagen informativa</string>
+    <string name="content_descriptions_implementation_actionable_icon">Icono accionable</string>
+    <string name="content_descriptions_implementation_decorative_image">Imagen decorativa</string>
+    <string name="content_descriptions_implementation_complex_graphic">Gráfico complejo</string>
+    <string name="content_descriptions_implementation_weather_description">Clima soleado con temperatura de 30 grados</string>
+    <string name="content_descriptions_implementation_profile_description">Foto de perfil de usuario</string>
+    <string name="content_descriptions_implementation_chart_description">Gráfico de barras mostrando ventas por trimestre</string>
+    <string name="content_descriptions_implementation_delete_button">Eliminar elemento</string>
+    <string name="content_descriptions_implementation_share_button">Compartir contenido</string>
+    <string name="content_descriptions_informative_title">Imágenes Informativas</string>
+    <string name="content_descriptions_actionable_title">Iconos Accionables</string>
+    <string name="content_descriptions_decorative_title">Elementos Decorativos</string>
+    <string name="content_descriptions_complex_title">Gráficos Complejos</string>
+    <string name="content_descriptions_contextual_title">Descripciones Contextuales</string>
+    <string name="content_descriptions_interactive_title">Componentes Interactivos</string>
+    <string name="content_descriptions_profile_picture">Foto de perfil de María González</string>
+    <string name="content_descriptions_close_dialog">Cerrar diálogo</string>
+    <string name="content_descriptions_add_to_favorites">Agregar a favoritos</string>
+    <string name="content_descriptions_rating_4_out_of_5">Calificación: 4 de 5 estrellas</string>
+    <string name="content_descriptions_status_online">Estado: En línea</string>
+    <string name="content_descriptions_article_card">Artículo: Título del artículo. Vista previa del texto. Tocar para leer más.</string>
+    <string name="content_descriptions_informative_explanation">Ejemplo de imagen informativa con descripción significativa para usuarios de tecnologías de asistencia.</string>
+    <string name="content_descriptions_actionable_explanation">Ejemplo de icono accionable con descripción que indica la acción que realiza.</string>
+    <string name="content_descriptions_decorative_explanation">Ejemplo de imagen decorativa sin descripción, ya que no aporta información relevante.</string>
+    <string name="content_descriptions_redundancy_title">Evitar Redundancia</string>
+    <string name="content_descriptions_redundancy_explanation">No repitas información que ya está visible en pantalla en la descripción de contenido.</string>
+    <string name="content_descriptions_redundancy_incorrect_explanation">El lector de pantalla anunciará dos veces: &quot;Eliminar elemento&quot;. Esto es redundante y puede confundir al usuario.</string>
+    <string name="content_descriptions_redundancy_correct_explanation">El lector de pantalla solo anunciará una vez: &quot;Eliminar elemento&quot;. Esto es claro y no redundante.</string>
+    <string name="content_descriptions_contextual_explanation">Adapta la descripción al estado o contexto actual del elemento para mayor claridad.</string>
+    <string name="content_descriptions_status_online_label">En línea</string>
+    <string name="content_descriptions_incorrect">Incorrecto</string>
+    <string name="content_descriptions_correct">Correcto</string>
+
+    <!-- Phone Number Accessibility -->
+    <string name="content_descriptions_phone_number_title">Accesibilidad de números de teléfono</string>
+    <string name="content_descriptions_phone_number_explanation">Los lectores de pantalla pueden leer los números de teléfono como una cifra larga, lo que puede resultar confuso. Usar una descripción de contenido con espacios entre los dígitos permite que se lea número por número.</string>
+    <string name="content_descriptions_phone_number_incorrect_label">Incorrecto</string>
+    <string name="content_descriptions_phone_number_correct_label">Correcto</string>
+    <string name="content_descriptions_phone_number_incorrect_explanation">El lector de pantalla leerá el número como una cifra larga.</string>
+    <string name="content_descriptions_phone_number_correct_explanation">El lector de pantalla leerá el número dígito por dígito.</string>
+    <string name="content_descriptions_phone_number_raw">656787434</string>
+    <string name="content_descriptions_phone_number_spaced">6 5 6 7 8 7 4 3 4</string>
 </resources>

--- a/app/src/main/res/values/urls.xml
+++ b/app/src/main/res/values/urls.xml
@@ -22,4 +22,11 @@
 
     <string name="toggleables_implementation_xml_documentation_url" translatable="false">https://github.com/Telefonica/accessibility-catalog/blob/HEAD/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/toggleables</string>
     <string name="toggleables_implementation_compose_documentation_url" translatable="false">https://github.com/Telefonica/accessibility-catalog/blob/HEAD/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/toggleables</string>
+
+    <!-- Content Descriptions -->
+    <string name="content_descriptions_related_link_1" translatable="false">https://developer.android.com/guide/topics/ui/accessibility/apps#describe-ui-element</string>
+    <string name="content_descriptions_related_link_2" translatable="false">https://www.magentaa11y.com/native-criteria/patterns/image-decorative</string>
+
+    <string name="content_descriptions_implementation_xml_documentation_url" translatable="false">https://github.com/Telefonica/accessibility-catalog/blob/HEAD/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/views/contentdescriptions</string>
+    <string name="content_descriptions_implementation_compose_documentation_url" translatable="false">https://github.com/Telefonica/accessibility-catalog/blob/HEAD/app/src/main/java/com/telefonica/apps/accessibility_catalog/view/screens/implementations/compose/contentdescriptions</string>
 </resources>


### PR DESCRIPTION
Added section info and examples about using content description for accessibility.

Some screenshots showing the new content:
|        |            |
| ------------- |-------------|
| <img width="300" alt="New Home Section" src="https://github.com/user-attachments/assets/05f992c5-1fba-48a3-bc0e-cdb8e8019c71" />      | <img width="300" alt="Content Description Info" src="https://github.com/user-attachments/assets/8fc43c53-1b1f-4612-8620-d70621e55157" /> |
| <img width="300" alt="Content Description Impl 1" src="https://github.com/user-attachments/assets/b3ee61ae-2582-4c9d-9d29-215b9481fedd" />      | <img width="300" alt="Content Description Impl 2" src="https://github.com/user-attachments/assets/58e11972-9854-4211-83c8-2b978b4bdc89" /> |






