### PR TITLE
Update libs ANDROID-17709

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,18 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
-    id 'com.google.dagger.hilt.android'
+    alias(libs.plugins.android.app)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
 }
 
 android {
     namespace 'com.telefonica.apps.accessibility_catalog'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.telefonica.apps.accessibility_catalog"
         minSdk 24
-        targetSdk 35
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 
@@ -32,9 +31,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
     buildFeatures {
         compose true
@@ -69,12 +65,7 @@ dependencies {
     debugImplementation libs.androidx.ui.test.manifest
 
     implementation libs.dagger
-    kapt libs.dagger.compiler
+    ksp libs.dagger.compiler
 
-    kapt libs.hilt.compiler
-}
-
-// Allow references to generated code
-kapt {
-    correctErrorTypes true
+    ksp libs.hilt.compiler
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.5.2' apply false
-    id 'com.android.library' version '8.5.2' apply false
-    id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
-    id 'com.google.dagger.hilt.android' version '2.52' apply false
+    alias(libs.plugins.android.app) apply false
+    alias(libs.plugins.android.lib) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.dependencies)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,20 @@
 [versions]
-activity-compose = "1.8.2"
-androidx-junit = "1.1.5"
-core-ktx = "1.12.0"
-dagger = "2.52"
-espresso-core = "3.5.1"
-hilt-android = "2.50"
-hilt-navigation-compose = "1.2.0"
+activity-compose = "1.13.0"
+agp = "9.2.0"
+androidx-junit = "1.3.0"
+core-ktx = "1.18.0"
+dagger = "2.59.2"
+espresso-core = "3.7.0"
+hilt-android = "2.59.2"
+hilt-navigation-compose = "1.3.0"
 junit = "4.13.2"
-lifecycle-runtime-ktx = "2.7.0"
-material3 = "1.2.0"
-mistica = "13.4.0"
-compose-version = "1.7.6"
-navigation-compose = "2.8.0-beta07"
-kotlin = "2.0.0"
+lifecycle-runtime-ktx = "2.10.0"
+material3 = "1.4.0"
+mistica = "25.4.1"
+compose-version = "1.11.0"
+navigation-compose = "2.9.8"
+kotlin = "2.3.21"
+ksp = "2.3.7"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
@@ -36,5 +38,9 @@ ui-tooling-main = { module = "androidx.compose.ui:ui-tooling", version.ref = "co
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-version" }
 
 [plugins]
-org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+android-app = { id = "com.android.application", version.ref = "agp" }
+android-lib = { id = "com.android.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt-android" }
+dependencies = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 15 13:03:36 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Libs update:

| Dependency/Plugin         | Before (Old Version) | After (New Version) |
|---------------------------|----------------------|---------------------|
| activity-compose          | 1.8.2                | 1.13.0              |
| agp (Android Gradle)      | —                    | 9.2.0               |
| androidx-junit            | 1.1.5                | 1.3.0               |
| core-ktx                  | 1.12.0               | 1.18.0              |
| dagger                    | 2.52                 | 2.59.2              |
| espresso-core             | 3.5.1                | 3.7.0               |
| hilt-android              | 2.50                 | 2.59.2              |
| hilt-navigation-compose   | 1.2.0                | 1.3.0               |
| lifecycle-runtime-ktx     | 2.7.0                | 2.10.0              |
| material3                 | 1.2.0                | 1.4.0               |
| mistica                   | 13.4.0               | 25.4.1              |
| compose-version           | 1.7.6                | 1.11.0              |
| navigation-compose        | 2.8.0-beta07         | 2.9.8               |
| kotlin                    | 2.0.0                | 2.3.21              |
| ksp                      | —                    | 2.3.7               |
| gradle-wrapper            | 8.7                  | 9.5.0               |

**Plugin alias changes:**
- Old plugins (e.g., `id 'com.android.application'`, `id 'org.jetbrains.kotlin.android'`, `id 'kotlin-kapt'`, etc.) were replaced with TOML-based plugin aliases (e.g., `alias(libs.plugins.android.app)`, `alias(libs.plugins.ksp)`, etc.).
- The `kapt` annotation processor was replaced with `ksp` for Dagger and Hilt.

**Other notable changes:**
- The AGP version is now managed via TOML and set to 9.2.0.
- Gradle wrapper updated from 8.7 to 9.5.0.